### PR TITLE
feat(gatsby-node.js): add option to only include upcoming events

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ module.exports = {
       options: {
         name: `events`,
         url: `https://web-standards.ru/calendar.ics`,
+        upcomingOnly: false, // set to `true` if you'd like to exclude past events
       },
     },
   ],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -45,7 +45,8 @@ function () {
     createNodeId
   }, {
     url,
-    name
+    name,
+    upcomingOnly
   }) {
     const createNode = actions.createNode;
     const data = yield fromURL(url, {});
@@ -57,7 +58,7 @@ function () {
 
       const datum = data[id];
 
-      if (datum.type === 'VEVENT') {
+      if (datum.type === 'VEVENT' && (!upcomingOnly || datum.start > new Date())) {
         createNode(processDatum(datum, createNodeId, name));
       }
     }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -34,7 +34,7 @@ function processDatum(datum, createNodeId, sourceInstanceName = "__PROGRAMMATIC_
 
 exports.sourceNodes = async (
   { actions, createNodeId },
-  { url, name }
+  { url, name, upcomingOnly }
 ) => {
   const { createNode } = actions;
 
@@ -47,7 +47,7 @@ exports.sourceNodes = async (
 
     const datum = data[id];
 
-    if (datum.type === 'VEVENT') {
+    if (datum.type === 'VEVENT' && (!upcomingOnly || datum.start > new Date())) {
       createNode(processDatum(datum, createNodeId, name));
     }
   }


### PR DESCRIPTION
this boolean option, if enabled, will exclude past events

i didn't look too deeply into it but a cooler option would be to provide a graphql `filter` for greater than/less than the event date.